### PR TITLE
Loosen "cloud-init finished" regex

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -110,7 +110,7 @@ func extractAddresses(srv *servers.Server) (map[string][]Address, error) {
 	return ret, nil
 }
 
-var initFinishedRe = regexp.MustCompile(`^.*Cloud-init\ v\.\ \d+\.\d+\.\d+\ finished\ at.*$`)
+var initFinishedRe = regexp.MustCompile(`^.*Cloud-init\ v\.\ .+\ finished\ at.*$`)
 
 func IsCloudInitFinished(log string) bool {
 	lines := strings.Split(log, "\n")


### PR DESCRIPTION
cloud-init version numbers are not necessarily only three digits, e.g.:

    Cloud-init v. 23.4.4-0ubuntu0~22.04.1 finished

Fixes #14