### PR TITLE
Make Openstack client microversion configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following parameters are supported:
 | `cloud`               | string | Name of the cloud config from clouds.yaml to use |
 | `clouds_config`       | string | Optional. Path to clouds.yaml |
 | `name`                | string | Name of the Auto Scaling Group (unique string that used to find instances) |
+| `client_microversion` | string | Microversion for the Openstack client |
 | `boot_time`           | string | Optional. Maximum wait time for instance to boot up. During that time plugin check Cloud-Init signatures. |
 | `use_ignition`        | string | Enable Fedora CoreOS / Flatcar Linux Ignition support |
 | `server_spec`         | object | Server spec used to create instances. See: [Compute API](https://docs.openstack.org/api-ref/compute/#create-server) |
@@ -110,6 +111,7 @@ plugin = "fleeting-plugin-openstack"
 cloud = "runner"
 clouds_config = "/etc/gitlab-runner/clouds.yaml"
 name = "scaling-runner-stack-id"
+client_microversion = "2.79" # train+
 boot_time = "10m"
 use_ignition = true  # enable injection of dynamic SSH key into Ignition config
 

--- a/provider.go
+++ b/provider.go
@@ -26,13 +26,14 @@ const MetadataKey = "fleeting-cluster"
 var _ provider.InstanceGroup = (*InstanceGroup)(nil)
 
 type InstanceGroup struct {
-	Cloud        string        `json:"cloud"`         // cloud to use
-	CloudsConfig string        `json:"clouds_config"` // optional: path to clouds.yaml
-	Name         string        `json:"name"`          // name of the cluster
-	ServerSpec   ExtCreateOpts `json:"server_spec"`   // instance creation spec
-	UseIgnition  bool          `json:"use_ignition"`  // Configure keys via Ignition (Fedora CoreOS / Flatcar)
-	BootTimeS    string        `json:"boot_time"`     // optional: wait some time before report machine as available
-	BootTime     time.Duration
+	Cloud              string        `json:"cloud"`               // cloud to use
+	CloudsConfig       string        `json:"clouds_config"`       // optional: path to clouds.yaml
+	Name               string        `json:"name"`                // name of the cluster
+	ClientMicroversion string        `json:"client_microversion"` // Microversion for the Openstack client
+	ServerSpec         ExtCreateOpts `json:"server_spec"`         // instance creation spec
+	UseIgnition        bool          `json:"use_ignition"`        // Configure keys via Ignition (Fedora CoreOS / Flatcar)
+	BootTimeS          string        `json:"boot_time"`           // optional: wait some time before report machine as available
+	BootTime           time.Duration
 
 	computeClient   *gophercloud.ServiceClient
 	settings        provider.Settings
@@ -66,7 +67,11 @@ func (g *InstanceGroup) Init(ctx context.Context, log hclog.Logger, settings pro
 		return provider.ProviderInfo{}, fmt.Errorf("Failed to connect to OpenStack Nova: %w", err)
 	}
 
-	cli.Microversion = "2.79" // train+
+	if g.ClientMicroversion != "" {
+		cli.Microversion = g.ClientMicroversion
+	} else {
+		cli.Microversion = "2.79" // train+
+	}
 	g.computeClient = cli
 
 	_, err = g.ServerSpec.ToServerCreateMap()


### PR DESCRIPTION
Some providers (like OVH) are currently limited to microversion "2.72". To enable a broader usability of this plugin the microversion should be configurable.