### PR TITLE
Honor runners.autoscaler.delete_instances_on_shutdown

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -390,25 +390,5 @@ func (g *InstanceGroup) ConnectInfo(ctx context.Context, instanceID string) (pro
 }
 
 func (g *InstanceGroup) Shutdown(ctx context.Context) error {
-
-	// Not necessary, after reboot all old nodes will be deleted anyway.
-	// But that speedup that process.
-	instances, err := g.getInstances(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, srv := range instances {
-		lg := g.log.With("id", srv.ID, "name", srv.Name)
-
-		err2 := g.deleteInstance(ctx, srv.ID)
-		if err2 != nil {
-			lg.Error("Failed to delete instance", "err", err2)
-			err = errors.Join(err, err2)
-		}
-
-		lg.Info("Deleted instance on shutdown")
-	}
-
-	return err
+	return nil
 }


### PR DESCRIPTION
Gitlab Runner itself has a config parameter (runners.autoscaler.delete_instances_on_shutdown) which can be used to remove instances on runner shutdown. There is no need to handle this ourself, Gitlab Runner (or better taskscaler) will mark all instances to be removed before shutting down.

See
* https://gitlab.com/gitlab-org/fleeting/taskscaler/-/blob/f3cdb5de12a49180a8da538decd0e023b62e3a41/options.go#L220-L228
* https://gitlab.com/gitlab-org/fleeting/taskscaler/-/blob/f3cdb5de12a49180a8da538decd0e023b62e3a41/taskscaler.go#L273

Fixes #43